### PR TITLE
add cutTitle function to prune the title down if two modules listed at end

### DIFF
--- a/sededu/modules/deltas/floodingindeltas/about.json
+++ b/sededu/modules/deltas/floodingindeltas/about.json
@@ -4,6 +4,7 @@
     "shortdesc": "Explore what flooding looks like in a delta",
     "version": "0.1",
     "projurl": "",
+    "difficulty":4,
     "projreadme": ["README.md"],
     "preview": ["private", "guidemo_gif.gif"],
     "exec": ["src", "backwater_flooding.py"],

--- a/sededu/modules/stratigraphy/RiversToStratigraphy/about.json
+++ b/sededu/modules/stratigraphy/RiversToStratigraphy/about.json
@@ -3,13 +3,13 @@
     "author": "Andrew J. Moodie",
     "shortdesc": "Explore how rivers make up different stratigraphic patters",
     "version": "1.0",
-    "projurl": "",
+    "projurl": "https://github.com/amoodie/rivers2stratigraphy",
     "projreadme": ["README.md"],
+    "difficulty": 5,
     "preview": ["private", "preview.png"],
     "exec": ["module", "rivers_to_stratigraphy.py"],
     "docloc": ["documents"],
     "doclist": {
         "worksheet.pdf": "Worksheet (Grades 10-12)"
     }
-
 }

--- a/sededu/sededuGUI.py
+++ b/sededu/sededuGUI.py
@@ -90,7 +90,7 @@ class CategoryMenu(QWidget):
         infoPageStack = categInfo.infoPageStack
         docPageStack = categInfo.docPageStack
 
-        categoryLabelText = gui.InfoLabel(category + " modules:")
+        categoryLabelText = gui.InfoLabel(gui.cutTitle(category + " modules:"))
         categoryLabelText.setFont(gui.titleFont())
         backBtn = gui.etcButton("Back to Main Menu")
         backBtn.clicked.connect(self.parent().drawMain)
@@ -99,7 +99,7 @@ class CategoryMenu(QWidget):
         bodyLayout.addWidget(categoryLabelText, 0, 0)
         bodyLayout.addWidget(moduleList, 1, 0)
         bodyLayout.addWidget(docPageStack, 2, 0)
-        # bodyLayout.addWidget(gui.VLine(self), 0, 1, 4, 1)
+        bodyLayout.addWidget(gui.VLine(self), 0, 1, 4, 1)
         bodyLayout.addWidget(infoPageStack, 0, 2, 4, 2)
         bodyLayout.addWidget(backBtn, 3, 0)
         self.setLayout(bodyLayout)

--- a/sededu/sededuGUI.py
+++ b/sededu/sededuGUI.py
@@ -99,7 +99,7 @@ class CategoryMenu(QWidget):
         bodyLayout.addWidget(categoryLabelText, 0, 0)
         bodyLayout.addWidget(moduleList, 1, 0)
         bodyLayout.addWidget(docPageStack, 2, 0)
-        bodyLayout.addWidget(gui.VLine(self), 0, 1, 4, 1)
+        # bodyLayout.addWidget(gui.VLine(self), 0, 1, 4, 1)
         bodyLayout.addWidget(infoPageStack, 0, 2, 4, 2)
         bodyLayout.addWidget(backBtn, 3, 0)
         self.setLayout(bodyLayout)

--- a/sededu/utilities/guiUtils.py
+++ b/sededu/utilities/guiUtils.py
@@ -306,5 +306,14 @@ def cutTitle(text0):
     # Use QFontMetrics to get measurements, 
     # e.g. the pixel length of a string using QFontMetrics.width().
     # cut the titles down to textextext... for the list widgets
-    text = text0
+
+    # also removes word module from end of string if two present
+    splt_t0 = text0.split()
+    spltend_t0 = splt_t0[-2:]
+    nospec_t0 = [ [''.join(e for e in x if e.isalnum()).lower()] 
+                 for x in spltend_t0 ]
+    if nospec_t0[0] == nospec_t0[1]: # if last two words are same (i.e., 'modules')
+        text = ' '.join(splt_t0[:-1]) + ":"
+    else:
+        text = text0
     return text

--- a/sededu/utilities/guiUtils.py
+++ b/sededu/utilities/guiUtils.py
@@ -48,7 +48,7 @@ class CategoryInfo(QWidget):
             iDocPageLayout.addWidget(self.iDocList)
             docLaunch = QPushButton("Open activity")
             docLaunch.clicked.connect(lambda: self.docLaunch(launchList))
-            iInfoPage.infoLayout.insertWidget(6, docLaunch)
+            iInfoPage.infoLayout.insertWidget(6, docLaunch) # THIS IS WHERE THE BUTTON SLIPS IN
             for iDoc in docList:
                 iDocInfo = iData["doclist"]
                 iDocTitle = list(iDocInfo.values())[docIdx]
@@ -90,14 +90,15 @@ class ModuleInfo(QWidget):
         optGroup = QGroupBox()
         optLayout = QGridLayout()
         optGroup.setLayout(optLayout)
-        # optLayout.setContentsMargins(0, 0, 0, 0)
+        optGroup.setFlat(True)
+        optLayout.setContentsMargins(2, 0, 2, 0)
         optLayoutInc = 0 # layout incrementer
         
         # check and add data if needed
         data = self.validateData(data)
         
         # handle required module fields
-        titleLabel = InfoLabel(data["title"])
+        titleLabel = InfoLabel(cutTitle(data["title"]))
         titleLabel.setFont(titleFont())
         infoLayout.addWidget(titleLabel)
         versionLabel = QLabel("version " + data["version"])
@@ -301,8 +302,9 @@ def titleFont():
     return font
 
 
-def cutTitle():
+def cutTitle(text0):
     # Use QFontMetrics to get measurements, 
     # e.g. the pixel length of a string using QFontMetrics.width().
     # cut the titles down to textextext... for the list widgets
-    a=1
+    text = text0
+    return text


### PR DESCRIPTION
this completes one issue/feature request. Cleans up the "Behind the Modules modules:" issue to now produce "Behind the Modules:".

Which in hindsight might seem kind of wrong, since they are in fact the "modules" about what occurs "behind the modules".

Anyway creating pull request to merge.